### PR TITLE
Fix TypeScript exports resolution by adding types condition to exports map

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,5 +17,6 @@ jobs:
     - name: npm install, build
       run: |
         npm install
+        npm run build
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.umd.cjs"
     }


### PR DESCRIPTION
Add 'types' condition to package.json exports field so TypeScript with
moduleResolution bundler/node16/nodenext can resolve the declaration file.
Also add npm run build to the CI workflow so PR builds are verified.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
